### PR TITLE
Add python-dotenv as dependency and update README

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,3 @@
 APP_ENV=Dev
+FLASK_APP=wsgi.py
+FLASK_ENV=development

--- a/README.md
+++ b/README.md
@@ -23,21 +23,20 @@ $ pip install -r requirements.txt
 
 ## Run the app
 
-You can run the app either via the `wsgi.py` as Flask app, or set the create_app config yourself.
+First copy `.env.sample` to a new `.env` file.
+
+You can run the app either via the `wsgi.py` as Flask app, or set the create_app config yourself in your .env file
 
 With wsgi.py:
 
+Set the `FLASK_APP` to `wsgi.py` in your `.env` file if its not set and do:
+
 ```bash
-$ export APP_ENV=Dev
-$ export FLASK_APP=wsgi.py
-$ export FLASK_ENV=development
 $ flask run
 ```
 
-or, directly:
+or, set the `FLASK_APP` environment variable to `'app:create_app("app.config.Dev")'` to set create_app config directly, and then do:
 
 ```bash
-$ export FLASK_APP='app:create_app("app.config.Dev")'
 $ flask run
 ```
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pylint
 pylint-flask
 pytest
 uuid==1.30
+python-dotenv


### PR DESCRIPTION
The `python-dotenv` dependency reads `.env` files to set environment variables, so when you run the application you don't need to set environment variables manually.