### PR TITLE
Update conftest.py and create test for user resource

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -10,3 +10,8 @@ class Dev(Config):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'database.db')
     PROPAGATE_EXCEPTIONS = True
+
+class Test(Config):
+    TESTING = True
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'test.db')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 from app import create_app
 
-@pytest.yield_fixture(scope='session')
+@pytest.fixture(scope='session')
 def flask_app():
 
     app = create_app('app.config.Test')
@@ -11,6 +11,7 @@ def flask_app():
 
     with app.app_context():
         db.init_app(app)
+        db.drop_all()
         db.create_all()
         yield app
 

--- a/tests/resources/test_user.py
+++ b/tests/resources/test_user.py
@@ -1,0 +1,37 @@
+import json
+
+def user_register_json(username, password, name, email):
+    return json.dumps(
+        {
+            "username": username,
+            "password": password,
+            "name": name,
+            "email": email
+        }
+    )
+
+def test_user_register_should_create_user(client):
+    res = client.post(
+        '/api/users/register',
+        data=user_register_json("user", "1234", "A user", "user@email.com"),
+        content_type='application/json'
+    )
+
+    assert res.status_code == 200
+
+def test_user_register_should_not_create_user(client):
+    res = client.post(
+        '/api/users/register',
+        data=user_register_json("user1", "12345", "A user1", "user1@email.com"),
+        content_type='application/json'
+    )
+
+    assert res.status_code == 200
+
+    res = client.post(
+        '/api/users/register',
+        data=user_register_json("user1", "12345", "A user1", "user1@email.com"),
+        content_type='application/json'
+    )
+
+    assert res.status_code == 400


### PR DESCRIPTION
In this PR I updated configtest.py and created a simple test for the `/api/users/register` API.

One issue that might become a problem in the future is shared db state between tests.

For example in the `test_user.py` there is one test that tests the `/api/users/register` for successful registration
and one test for `/api/users/register` that tests for unsuccessful registration(ex. duplicate user).

Both of these tests share the same db.